### PR TITLE
removed double download and added simple check already loaded files

### DIFF
--- a/DSpace_OAI-PMH/dspace_download.py
+++ b/DSpace_OAI-PMH/dspace_download.py
@@ -45,7 +45,7 @@ def get_data(input_dir, replace):
         count += 1
         tqdm.write(f"{count}/{total_records}")
         for file in files:
-            if file.endswith(".xml"):
+            if file.endswith(".xml") and len(files) == 1:
 
                 with open(os.path.join(root, file), 'r', encoding='utf-8', errors='ignore') as file:
                     metsfile = file.read()
@@ -61,7 +61,6 @@ def get_data(input_dir, replace):
                             if replace:
                                 url = href[0].replace(replace[0], replace[1])
 
-                            download_file(url, root, file_id)
                             try:
                                 download_file(url, root, file_id)
 


### PR DESCRIPTION
This PR removes extra download line causing halt on error and double files. Also added simple check for already downloaded files, so one can run script again without downloading everything again in case you get full disk or something similar. 